### PR TITLE
fix(germline_var): fix link

### DIFF
--- a/gdcdictionary/schemas/germline_variation_catalog.yaml
+++ b/gdcdictionary/schemas/germline_variation_catalog.yaml
@@ -22,10 +22,10 @@ systemProperties:
   - error_type
 
 links:
-  - name: alignment_workflows
+  - name: germline_mutation_calling_workflows
     backref: germline_variation_catalogs
     label: data_from
-    target_type: alignment_workflow
+    target_type: germline_mutation_calling_workflow
     multiplicity: one_to_one
     required: true
 
@@ -67,5 +67,5 @@ properties:
       - WXS
       - Low Pass WGS
       - Validation
-  alignment_workflows:
+  germline_mutation_calling_workflows:
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/germline_variation_catalog.yaml
+++ b/gdcdictionary/schemas/germline_variation_catalog.yaml
@@ -22,10 +22,10 @@ systemProperties:
   - error_type
 
 links:
-  - name: germline_mutation_calling_workflows
+  - name: alignment_workflows
     backref: germline_variation_catalogs
     label: data_from
-    target_type: germline_mutation_calling_workflow
+    target_type: alignment_workflow
     multiplicity: one_to_one
     required: true
 
@@ -38,7 +38,6 @@ required:
   - data_type
   - data_format
   - experimental_strategy
-  - germline_mutation_calling_workflows
 
 uniqueKeys:
   - [ id ]

--- a/gdcdictionary/schemas/germline_variation_catalog.yaml
+++ b/gdcdictionary/schemas/germline_variation_catalog.yaml
@@ -66,5 +66,5 @@ properties:
       - WXS
       - Low Pass WGS
       - Validation
-  germline_mutation_calling_workflows:
+  alignment_workflows:
     $ref: "_definitions.yaml#/to_one"


### PR DESCRIPTION
Fix links in the germline_variation node to connect with the correct germline_variant_calling_workflow instead of alignment_workflow