### PR TITLE
feat(sgv): rm required link

### DIFF
--- a/gdcdictionary/schemas/simple_germline_variation.yaml
+++ b/gdcdictionary/schemas/simple_germline_variation.yaml
@@ -46,7 +46,6 @@ required:
   - data_type
   - data_format
   - experimental_strategy
-  - germline_mutation_calling_workflows
 
 uniqueKeys:
   - [ id ]


### PR DESCRIPTION
Fix required link from simple germline variants to workflow. No required anymore.